### PR TITLE
Feature: Media Notification Close Action and Auto-cleanup

### DIFF
--- a/app/src/main/java/com/omymaxz/download/MainActivity.kt
+++ b/app/src/main/java/com/omymaxz/download/MainActivity.kt
@@ -544,6 +544,9 @@ private fun checkBatteryOptimization() {
             }
 
             val wasCurrentTabDeleted = selectedPositions.contains(currentTabIndex)
+            if (wasCurrentTabDeleted) {
+                stopPlaybackService()
+            }
             var deletedBeforeCurrent = 0
 
             for (pos in selectedPositions) {
@@ -614,6 +617,7 @@ private fun checkBatteryOptimization() {
         val closingCurrentTab = position == currentTabIndex
         tabs.removeAt(position)
         if (closingCurrentTab) {
+            stopPlaybackService()
             val newIndex = if (position > 0) position - 1 else 0
             switchTab(newIndex, forceReload = true)
         } else {

--- a/app/src/main/java/com/omymaxz/download/MediaForegroundService.kt
+++ b/app/src/main/java/com/omymaxz/download/MediaForegroundService.kt
@@ -222,11 +222,38 @@ class MediaForegroundService : Service() {
             )
         }
 
+
+        // Add close action
+        builder.addAction(
+            NotificationCompat.Action(
+                R.drawable.ic_close,
+                "Close",
+                MediaButtonReceiver.buildMediaButtonPendingIntent(this, PlaybackStateCompat.ACTION_STOP)
+            )
+        )
+
         // Set the style using the MediaSession token
+        val actionIndices = mutableListOf<Int>()
+        var currentIndex = 0
+
+        if (hasPrevious) {
+            currentIndex++
+        }
+
+        val playPauseIndex = currentIndex++
+        actionIndices.add(playPauseIndex)
+
+        if (hasNext) {
+            currentIndex++
+        }
+
+        val closeIndex = currentIndex++
+        actionIndices.add(closeIndex)
+
         builder.setStyle(
             androidx.media.app.NotificationCompat.MediaStyle()
                 .setMediaSession(mediaSession?.sessionToken)
-                .setShowActionsInCompactView(0, 1, 2) // Adjust indices based on how many actions you add (0-indexed)
+                .setShowActionsInCompactView(*actionIndices.toIntArray())
         )
 
         return builder.build()


### PR DESCRIPTION
Resolves an issue where the media notification persists when a background tab is closed and gives users an explicit way to close the media notification directly from the notification UI.

---
*PR created automatically by Jules for task [16673881856958380388](https://jules.google.com/task/16673881856958380388) started by @omy1maxz-alt*