### PR TITLE
feat: add close button to media notification and auto-close on tab de…

### DIFF
--- a/app/src/main/java/com/omymaxz/download/MainActivity.kt
+++ b/app/src/main/java/com/omymaxz/download/MainActivity.kt
@@ -159,6 +159,15 @@ class MainActivity : AppCompatActivity() {
                         binding.webView.evaluateJavascript("window.AndroidMediaController.previous();", null)
                     }
                     MediaForegroundService.ACTION_STOP_SERVICE -> {
+                        for (tab in tabs) {
+                            if (tab.isMediaPlaying) {
+                                tab.isMediaPlaying = false
+                                if (tab == tabs[currentTabIndex]) {
+                                    binding.webView.evaluateJavascript("window.AndroidMediaController.pause();", null)
+                                }
+                            }
+                        }
+
                         binding.webView.evaluateJavascript("window.AndroidMediaController.pause();", null)
                         stopPlaybackService()
                         isMediaPlaying = false
@@ -544,14 +553,17 @@ private fun checkBatteryOptimization() {
             }
 
             val wasCurrentTabDeleted = selectedPositions.contains(currentTabIndex)
-            if (wasCurrentTabDeleted) {
-                stopPlaybackService()
-            }
+
             var deletedBeforeCurrent = 0
 
             for (pos in selectedPositions) {
                 if (pos < currentTabIndex) {
                     deletedBeforeCurrent++
+                }
+                val closingTab = tabs[pos]
+                if (closingTab.isMediaPlaying) {
+                    stopPlaybackService()
+                    isMediaPlaying = false
                 }
                 tabs.removeAt(pos)
             }
@@ -615,9 +627,15 @@ private fun checkBatteryOptimization() {
             return
         }
         val closingCurrentTab = position == currentTabIndex
+
+        val closingTab = tabs[position]
+        if (closingTab.isMediaPlaying) {
+            stopPlaybackService()
+            isMediaPlaying = false
+        }
+
         tabs.removeAt(position)
         if (closingCurrentTab) {
-            stopPlaybackService()
             val newIndex = if (position > 0) position - 1 else 0
             switchTab(newIndex, forceReload = true)
         } else {


### PR DESCRIPTION
…letion

* Added a 'Close' action (ACTION_STOP) to `MediaForegroundService`'s notification.
* Reconfigured `setShowActionsInCompactView` to ensure Play/Pause and Close actions are visible in the collapsed notification state.
* Intercepted `ACTION_STOP_SERVICE` in `MainActivity` to properly set `isMediaPlaying = false` for background tabs and stop playback.
* Updated tab deletion logic in `MainActivity` to detect if the closed tab was currently playing media, automatically stopping the background playback service to dismiss the notification.